### PR TITLE
Add support for strategy.matrix builds

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -40,6 +40,32 @@ Install conan_package_tools before running the build script if the value is not
 `no`. If the value is `latest` install the latest version, otherwise install
 the version equal to that value. `latest` by default.
 
+The following parameters allow you to customize conan and conan_package_tools behaviour.
+It is conrolled by environment variables and there is no way to undefine a variable from
+a workflow file after it was set. For example, you cannot set CONAN_DOCKER_IMAGE and
+then unset it. This does not allow you to use strategy.matrix to run several jobs
+based on a single job description. With the following parameters you can setup the behaviour
+without using environment variables from a workflow file. The values of these parameters
+override the values of the corresponding environment variables, so you can setup default
+environment variables and modify the behaviour of a conan for some jobs/steps exclusively.
+
+compiler::
+Sets which compiler conan should use. Use this option in a combination with an option
+`compiler-versions`. Defaults to an empty string, conan_package_tools will choose a compiler
+based on environment variables in this case. Other supported values are:
+* gcc
+* apple_clang
+* vs
+compiler-versions::
+**Required if `compiler` is set** While `compiler` option chooses which environment variable
+to setup, this option sets its value:
+* CONAN_GCC_VERSIONS
+* CONAN_APPLE_CLANG_VERIONS
+* CONAN_VISUAL_VERIONS
+docker-image::
+Overrides or clears CONAN_DOCKER_IMAGE environment variable. Set to an empty string to do nothing.
+Set to 'clear' to undefine the environment variable. Defaults to an empty string.
+
 == Maintainer
 Dmitry Arkhipov <grisumbras@gmail.com>
 

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,18 @@ inputs:
     description: what version of conan_package_tools to install
     required: false
     default: latest
+  compiler:
+    description: a compiler to use. An empty string if you set compiler version via env vars. One of ['gcc', 'apple_clang', 'vs'] otherwise.
+    required: false
+    default:
+  compiler-versions:
+    description: list of comma-separated versions or an empty string if you set compiler version via environment variables. Required if you've set compiler option.
+    required: false
+    default:
+  docker-image:
+    description: sets CONAN_DOCKER_IMAGE environment variable, set to 'clear' to delete this environment variable. An empty string - do nothing.
+    required: false
+    default:
 runs:
   using: node12
   main: main.js

--- a/run.js
+++ b/run.js
@@ -24,6 +24,54 @@ function get_cpt_version() {
 };
 
 
+function setup_compiler() {
+  const compiler = core.getInput('compiler');
+  const compiler_versions = core.getInput('compiler-versions');
+  if (!compiler) {
+    return;
+  }
+  console.log(`Setting compiler options...`);
+  if (!compiler_versions) {
+    throw Error('compiler-versions are not specified');
+  }
+
+  switch (compiler) {
+    case 'gcc':
+      process.env.CONAN_GCC_VERSIONS = compiler_versions;
+      break;
+    case 'apple_clang':
+      process.env.CONAN_APPLE_CLANG_VERSIONS = compiler_versions;
+      break;
+    case 'vs':
+      process.env.CONAN_VISUAL_VERSIONS = compiler_versions;
+      break;
+    case '':
+      break;
+    default:
+      throw Error('Unknown compiler, either set this value to an empty string or ' +
+        'to one of supported compilers: [gcc, apple_clang, vs]');
+  }
+  console.log(`compiler: ${compiler}`);
+  console.log(`compiler versions: ${compiler_versions}`);
+}
+
+
+function setup_docker_image() {
+  const docker_image = core.getInput('docker-image');
+  if (!docker_image) {
+    return;
+  }
+  console.log(`Setting docker image...`);
+  if (docker_image === 'clear') {
+    delete process.env.CONAN_DOCKER_IMAGE;
+    console.log(`CONAN_DOCKER_IMAGE env var is deleted`);
+  } else {
+    process.env.CONAN_DOCKER_IMAGE = docker_image;
+    console.log(`CONAN_DOCKER_IMAGE env var is set to ${docker_image}`);
+  }
+}
+
+
 async function run() {
   const cpt_version = get_cpt_version();
   if (cpt_version) {
@@ -31,6 +79,8 @@ async function run() {
     await exec.exec('pip', ["install", cpt_version]);
   }
 
+  setup_compiler();
+  setup_docker_image();
   const opts
     = { env: Object.assign({CONAN_USERNAME: get_username()}, process.env)
       };
@@ -44,4 +94,6 @@ module.exports =
   { run: run
   , get_username: get_username
   , get_cpt_version: get_cpt_version
+  , setup_compiler: setup_compiler
+  , setup_docker_image: setup_docker_image
   };


### PR DESCRIPTION
The behaviour of conan and conan_package_tools
is conrolled by environment variables
and there is no way to undefine a variable from
a workflow file after it was set.

For example, you cannot set CONAN_DOCKER_IMAGE
and then unset it.

This does not allow you to use strategy.matrix
to run several jobs based on a single job description.

This commit adds several input arguments to overcome
this issue. If set these arguments override the
corresponding environment variables:
* compiler
* commpiler-versions
* docker-image